### PR TITLE
Update tasks to use become: yes instead of sudo; use homebrew

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,25 +5,18 @@
 - name: Configure dnsmasq
   copy: src=dnsmasq.conf dest=/usr/local/etc/dnsmasq.conf
 
-- name: Create dnsmasq launchctl configuration
-  copy:
-    src: /usr/local/opt/dnsmasq/homebrew.mxcl.dnsmasq.plist
-    dest: /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
-    owner: root
-  sudo: yes
-
-- name: Start dnsmasq
-  shell: launchctl load /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
-  sudo: yes
-
 - name: Make /etc/resolver
   file:
     path: /etc/resolver
     group: admin
     mode: 0755
     state: directory
-  sudo: yes
+  become: yes
 
 - name: Configure dnsmasq to serve *.dev
   copy: src=resolver.dev dest=/etc/resolver/dev
-  sudo: yes
+  become: yes
+  
+- name: Start dnsmasq
+  shell: brew services start dnsmasq
+  become: yes


### PR DESCRIPTION
A few updates to the playbook.

* Swap `sudo` for `become`
* Use `brew services start` instead of `launchctl` directly
* Move starting to the last task after the resolver has been configured.